### PR TITLE
Fix pip typo (egg=cartodb), add some links, add code styling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following example requires your CartoDB API consmer key and consumer secret.
 
 
 ```python
-import cartodb
+from cartodb import CartoDB, CartoDBException
 
 user =  'me@mail.com'
 password =  'secret'


### PR DESCRIPTION
Just a minor documentation update with a typo fix on the pip command, some links, and code styling in the usage example. :)
