### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
-# What is cartodb-python? #
+What is cartodb-python?
+=======================
 
-The cartodb-python project is a Python client for the [CartoDB SQL API](http://developers.cartodb.com/api/sql.html) that supports [authentication using OAuth](http://developers.cartodb.com/api/authentication.html).
+The cartodb-python project is a Python client for the [CartoDB SQL
+API](http://developers.cartodb.com/documentation/sql-api.html) that supports
+[authentication using OAuth or API
+key](http://developers.cartodb.com/documentation/sql-api.html#authentication).
 
-# Installation #
+Installation
+============
 
-You can install cartodb-python by cloning this repository or by using [Pip](http://pypi.python.org/pypi/pip), a Python package installer similar to easy_install.
+You can install cartodb-python by cloning this repository or by using
+[Pip](http://pypi.python.org/pypi/pip), a Python package installer similar to
+easy\_install:
 
-```bash
-pip install cartodb
-```
+    pip install cartodb
 
-or if you want to use the development version
+Or if you want to use the development version:
 
-```bash
-pip install -e git+git://github.com/Vizzuality/cartodb-python.git#egg=cartodb
-```
+    pip install -e git+git://github.com/Vizzuality/cartodb-python.git#egg=cartodb
 
-Note that cartodb-python depends on the ouath2 module
+Note that cartodb-python depends on the ouath2 module:
 
-```bash
-pip install oauth2
-```
+    pip install oauth2
 
-and if you're running python < 2.6 you need to install simplejson
+And if you're running python prior to 2.6 you need to install simplejson:
 
-```bash
-pip install simplejson
-```
+    pip install simplejson
 
+Usage example
+=============
 
-# Usage example #
+The following example requires your **CartoDB API consmer key and consumer
+secret** or the **API KEY**. Refer to the [CartoDB Authentication
+documentation](http://developers.cartodb.com/documentation/cartodb-apis.html#authentication)
+for details.
 
-The following example requires your **CartoDB API consmer key and consumer secret** or the **API KEY**. Refer to the [CartoDB Authentication documentation](http://developers.cartodb.com/documentation/cartodb-apis.html#authentication) for details.
-
-## using oAuth
+Using oAuth
+-----------
 
 ```python
 from cartodb import CartoDBOAuth, CartoDBException
@@ -45,12 +48,13 @@ CONSUMER_SECRET='YOUR_CARTODB_CONSUMER_SECRET'
 cartodb_domain = 'YOUR_CARTODB_DOMAIN'
 cl = CartoDBOAuth(CONSUMER_KEY, CONSUMER_SECRET, user, password, cartodb_domain)
 try:
-    print cl.sql('select * from mytable')
+print cl.sql('select * from mytable')
 except CartoDBException as e:
-    print ("some error ocurred", e)
+print ("some error ocurred", e)
 ```
 
-## using API KEY
+Using API KEY
+-------------
 
 You can get you api key in https://YOUR_USER.cartodb.com/your_apps/api_key
 
@@ -62,14 +66,16 @@ API_KEY ='YOUR_CARTODB_API_KEY'
 cartodb_domain = 'YOUR_CARTODB_DOMAIN'
 cl = CartoDBAPIKey(API_KEY, cartodb_domain)
 try:
-    print cl.sql('select * from mytable')
+print cl.sql('select * from mytable')
 except CartoDBException as e:
-    print ("some error ocurred", e)
+print ("some error ocurred", e)
 ```
 
-# Note for people using version 0.4 
+Note for people using version 0.4
+==================================
 
-With the new API key auth now you have two options to authenticate so the class CartoDB has been replaced with CartoDBOAuth and CartoDBAPIKey.
+With the new API key auth now you have two options to authenticate so the class
+CartoDB has been replaced with CartoDBOAuth and CartoDBAPIKey.
 
 In order to migrate your code to this version you have to replace
 
@@ -83,14 +89,10 @@ by
 from cartodb import CartoDBOAuth as CartoDB
 ```
 
-# running tests
+Running tests
+=============
 
-clone the repo, create a secret.py from secret.py.example, fill the variables and execute:
+Clone the repo, create a secret.py from secret.py.example, fill the variables
+and execute:
 
-```base
-python setup.py test
-```
-
-
-
-
+    python setup.py test


### PR DESCRIPTION
The links to the documentation were outdated using the /api/ url.

I've changed the line widths and tabulations to make it more readable
from console/editor.
