### PR TITLE
Auth and SQL clients store base_url and username, base_url doesn't expect trailing /api anymore

### DIFF
--- a/carto/auth.py
+++ b/carto/auth.py
@@ -1,6 +1,12 @@
+import re
+import sys
 import warnings
 from pyrestcli.auth import BaseAuthClient
 
+if sys.version_info >= (3,0):
+    from urllib.parse import urlparse
+else:
+    from urlparse import urlparse
 
 class APIKeyAuthClient(BaseAuthClient):
     """
@@ -20,6 +26,19 @@ class APIKeyAuthClient(BaseAuthClient):
 
         self.organization = organization
         self.api_key = api_key
+        self.base_url = base_url
+
+        url_info = urlparse(base_url)
+        # Cloud multiuser organization:
+        #   /u/<username>/api
+        # On-Prem:
+        #   /user/<username>/api
+        m = re.search('^/u(?:ser)?/(.*?)/api', url_info.path)
+        if m is None:
+            # Cloud personal account
+            # <username>.carto.com
+            m = re.search('^(.*?)\..*', url_info.netloc)
+        self.username = m.group(1)
 
         super(APIKeyAuthClient, self).__init__(base_url, proxies=proxies)
 

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -26,14 +26,17 @@ class APIKeyAuthClient(BaseAuthClient):
 
         self.organization = organization
         self.api_key = api_key
-        self.base_url = base_url
+
+        # Make sure there is a trailing / for urljoin
+        if not base_url.endswith('/'):
+            base_url += '/'
 
         url_info = urlparse(base_url)
         # Cloud multiuser organization:
-        #   /u/<username>/api
+        #   /u/<username>
         # On-Prem:
-        #   /user/<username>/api
-        m = re.search('^/u(?:ser)?/(.*?)/api', url_info.path)
+        #   /user/<username>
+        m = re.search('^/u(?:ser)?/(.*)/$', url_info.path)
         if m is None:
             # Cloud personal account
             # <username>.carto.com

--- a/carto/datasets.py
+++ b/carto/datasets.py
@@ -15,7 +15,7 @@ from .resources import Manager
 
 
 API_VERSION = "v1"
-API_ENDPOINT = "{api_version}/viz/"
+API_ENDPOINT = "api/{api_version}/viz/"
 
 MAX_NUMBER_OF_RETRIES = 30
 INTERVAL_BETWEEN_RETRIES_S = 5

--- a/carto/export.py
+++ b/carto/export.py
@@ -4,7 +4,7 @@ from .resources import AsyncResource
 
 
 API_VERSION = "v3"
-API_ENDPOINT = '{api_version}/visualization_exports/'
+API_ENDPOINT = 'api/{api_version}/visualization_exports/'
 
 
 class ExportJob(AsyncResource):

--- a/carto/file_import.py
+++ b/carto/file_import.py
@@ -5,7 +5,7 @@ from .paginators import CartoPaginator
 
 
 API_VERSION = "v1"
-API_ENDPOINT = '{api_version}/imports/'
+API_ENDPOINT = 'api/{api_version}/imports/'
 
 
 class FileImportJob(AsyncResource):

--- a/carto/maps.py
+++ b/carto/maps.py
@@ -4,7 +4,7 @@ from carto.core import Resource, Manager
 
 
 API_VERSION = "v1"
-API_ENDPOINT = "{api_version}/map/named/"
+API_ENDPOINT = "api/{api_version}/map/named/"
 
 
 class NamedMap(Resource):

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -1,5 +1,5 @@
-SQL_API_URL = '{api_version}/sql'
-SQL_BATCH_API_URL = '{api_version}/sql/job/'
+SQL_API_URL = 'api/{api_version}/sql'
+SQL_BATCH_API_URL = 'api/{api_version}/sql/job/'
 
 MAX_GET_QUERY_LEN = 1024
 
@@ -16,6 +16,10 @@ class SQLClient(object):
         """
         self.auth_client = auth_client
         self.api_url = SQL_API_URL.format(api_version=api_version)
+
+        self.api_key = self.auth_client.api_key
+        self.base_url = self.auth_client.base_url
+        self.username = self.auth_client.username
 
     def send(self, sql, parse_json=True, do_post=True, format=None):
         """

--- a/carto/sync_tables.py
+++ b/carto/sync_tables.py
@@ -10,7 +10,7 @@ from .paginators import CartoPaginator
 
 
 API_VERSION = "v1"
-API_ENDPOINT = '{api_version}/synchronizations'
+API_ENDPOINT = 'api/{api_version}/synchronizations'
 API_FORCE_SYNC_SUFFIX = 'sync_now'
 
 

--- a/carto/tables.py
+++ b/carto/tables.py
@@ -7,7 +7,7 @@ from .resources import Manager
 
 
 API_VERSION = "v1"
-API_ENDPOINT = "{api_version}/tables/"
+API_ENDPOINT = "api/{api_version}/tables/"
 
 
 class Table(Resource):

--- a/carto/users.py
+++ b/carto/users.py
@@ -13,7 +13,7 @@ from .resources import Manager
 
 
 API_VERSION = "v1"
-API_ENDPOINT = "{api_version}/organization/{organization}/users/"
+API_ENDPOINT = "api/{api_version}/organization/{organization}/users/"
 
 
 class User(Resource):

--- a/carto/visualizations.py
+++ b/carto/visualizations.py
@@ -12,7 +12,7 @@ from .export import ExportJob
 
 
 API_VERSION = "v1"
-API_ENDPOINT = "{api_version}/viz/"
+API_ENDPOINT = "api/{api_version}/viz/"
 
 MAX_NUMBER_OF_RETRIES = 30
 INTERVAL_BETWEEN_RETRIES_S = 5

--- a/tests/client.py
+++ b/tests/client.py
@@ -7,6 +7,31 @@ from carto import CartoException, APIKeyAuthClient, NoAuthClient, FileImport, UR
 from secret import API_KEY, USERNAME, EXISTING_POINT_DATASET, EXPORT_VIZ_ID, IMPORT_FILE, IMPORT_URL, NAMED_MAP_AUTH_TOKEN, NAMED_MAP_DEFINITION, NAMED_MAP_INSTANTIATION, BATCH_SQL_SINGLE_QUERY, BATCH_SQL_MULTI_QUERY
 
 
+class APIKeyAuthClientTest(unittest.TestCase):
+    def test_cloud_personal_url(self):
+        user1 = APIKeyAuthClient('https://user1.carto.com/a/b/c', API_KEY).username
+        user2 = APIKeyAuthClient('https://www.user2.carto.com', API_KEY).username
+        user3 = APIKeyAuthClient('http://www.user3.carto.com/a/b/c', API_KEY).username
+        self.assertEqual(user1, 'user1')
+        self.assertEqual(user2, 'user2')
+        self.assertEqual(user3, 'user3')
+
+    def test_cloud_organization_url(self):
+        user1 = APIKeyAuthClient('https://carto.com/u/user1/a/b/c', API_KEY).username
+        user2 = APIKeyAuthClient('https://www.carto.com/u/user2', API_KEY).username
+        user3 = APIKeyAuthClient('http://www.carto.com/u/user3/a/b/c', API_KEY).username
+        self.assertEqual(user1, 'user1')
+        self.assertEqual(user2, 'user2')
+        self.assertEqual(user3, 'user3')
+
+    def test_on_prem_url(self):
+        user1 = APIKeyAuthClient('https://carto.com/user/user1/a/b/c', API_KEY).username
+        user2 = APIKeyAuthClient('https://www.carto.com/user/user2', API_KEY).username
+        user3 = APIKeyAuthClient('http://www.carto.com/user/user3/a/b/c', API_KEY).username
+        self.assertEqual(user1, 'user1')
+        self.assertEqual(user2, 'user2')
+        self.assertEqual(user3, 'user3')
+
 class SQLClientTest(unittest.TestCase):
     def setUp(self):
         self.client = APIKeyAuthClient(API_KEY, USERNAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from carto.users import UserManager
 from secret import USERNAME, API_KEY, ORGANIZATION
 
 
-BASE_URL = "https://{organization}.carto.com/user/{user}/api/".format(organization=ORGANIZATION, user=USERNAME)
+BASE_URL = "https://{organization}.carto.com/user/{user}/".format(organization=ORGANIZATION, user=USERNAME)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
The changes include:
- Auth extracts username from base_url, removing special logic for different cloud/on-prem versions
- Auth + SQL clients store base_url and username for other methods to use if needed
- Removed the trailing /api in base_url (Issue #45)

I added Auth tests but I couldn't get

```python
python setup.py test
```

running properly, I get

```bash
[~/git/carto-python]
> py setup.py test
running test
```

even when setting the assert to fail