### PR TITLE
excludes carto.com/u/<username> since api endpoints go to <username>.carto.com

### DIFF
--- a/carto/auth.py
+++ b/carto/auth.py
@@ -32,13 +32,11 @@ class APIKeyAuthClient(BaseAuthClient):
             base_url += '/'
 
         url_info = urlparse(base_url)
-        # Cloud multiuser organization:
-        #   /u/<username>
         # On-Prem:
         #   /user/<username>
-        m = re.search('^/u(?:ser)?/([^/]+)/.*$', url_info.path)
+        m = re.search('^/user/([^/]+)/.*$', url_info.path)
         if m is None:
-            # Cloud personal account
+            # Cloud personal account (org and standalone)
             # <username>.carto.com
             netloc = url_info.netloc
             if netloc.startswith('www.'):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,14 +12,6 @@ def test_cloud_personal_url():
     assert user2 == 'user2'
     assert user3 == 'user3'
 
-def test_cloud_organization_url():
-    user1 = APIKeyAuthClient('https://carto.com/u/user1/a/b/c', API_KEY).username
-    user2 = APIKeyAuthClient('https://www.carto.com/u/user2', API_KEY).username
-    user3 = APIKeyAuthClient('http://www.carto.com/u/user3/a/b/c', API_KEY).username
-    assert user1 == 'user1'
-    assert user2 == 'user2'
-    assert user3 == 'user3'
-
 def test_on_prem_url():
     user1 = APIKeyAuthClient('https://carto.com/user/user1/a/b/c', API_KEY).username
     user2 = APIKeyAuthClient('https://www.carto.com/user/user2', API_KEY).username


### PR DESCRIPTION
I erroneously told @dmed256 that `https://carto.com/u/<username>` was a valid base url. I'm fixing that here. If someone does put in a baseurl of that form, though, it will error. We should probably have better error reporting around that.