### PR TITLE
Add a meaningful User-Agent header and client param

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 Mmm-dd-yyyy: version 1.3.0
  - Added a `CopySQLClient` for efficient streaming of data to and from CARTO (#87)
  - Fixed CI tests
+ - Added a request header `User-Agent: carto-python-sdk/x.y.z` where `x.y.z` is the current version of the library.
+ - Added a `client=cps-x.y.z` parameter to requests, where `x.y.z` is the current version of the library.
 
 Feb-22-2028: version 1.2.2
  - Updated release instructions in CONTRIBUTING.md

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -134,18 +134,16 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier, Base
 
     def prepare_send(self, http_method, **requests_args):
         http_method = http_method.lower()
+        params = {
+            "api_key": self.api_key,
+            "client": self.client_id
+        }
         if (http_method in ['post', 'put']) and "json" in requests_args:
-            requests_args["json"].update({
-                "api_key": self.api_key,
-                "client": self.client_id
-            })
+            requests_args["json"].update(params)
         else:
             if "params" not in requests_args:
                 requests_args["params"] = {}
-            requests_args["params"].update({
-                "api_key": self.api_key,
-                "client": self.client_id
-            })
+            requests_args["params"].update(params)
 
         if 'headers' not in requests_args or not requests_args['headers']:
             requests_args['headers'] = {}

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -145,7 +145,7 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier, Base
                 requests_args["params"] = {}
             requests_args["params"].update(params)
 
-        if 'headers' not in requests_args or not requests_args['headers']:
+        if not requests_args.get('headers', None):
             requests_args['headers'] = {}
         requests_args['headers'].update({'User-Agent': self.user_agent})
 

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -135,7 +135,7 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier, Base
                 requests_args["params"] = {}
             requests_args["params"].update({"api_key": self.api_key})
 
-        if 'headers' not in requests_args:
+        if 'headers' not in requests_args or not requests_args['headers']:
             requests_args['headers'] = {}
         requests_args['headers'].update({'User-Agent': self.user_agent})
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -118,4 +118,10 @@ def test_user_agent():
                          request_headers={'User-Agent': expected_user_agent})
 
     client = APIKeyAuthClient('file://test.carto.com', 'some_api_key', None, session)
-    resp = client.send('headers', 'post')
+    client.send('headers', 'post')
+
+def test_client_id_in_requests():
+    expected_client_id = _ClientIdentifier().get_client_identifier()
+    client = APIKeyAuthClient('https://test.carto.com', 'some_api_key')
+    http_method, requests_args = client.prepare_send('post')
+    assert requests_args['params']['client'] == expected_client_id

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 import pytest
+import re
 
 from secret import API_KEY
 from carto.auth import APIKeyAuthClient
 from carto.exceptions import CartoException
 from conftest import USR_BASE_URL, DEFAULT_PUBLIC_API_KEY
 from carto.auth import AuthAPIClient
+from carto.auth import _ClientIdentifier
 
 
 def test_wrong_url():
@@ -92,3 +94,13 @@ def test_auth_api_is_valid_api_key_with_master_key():
     if API_KEY == 'mockmockmock':
         pytest.skip("Can't be tested with mock api key")
     assert AuthAPIClient(USR_BASE_URL, API_KEY).is_valid_api_key()
+
+
+def test_client_identifier():
+    ci = _ClientIdentifier()
+
+    client_id_pattern = re.compile('carto-python-sdk/\d+\.\d+\.\d+')
+    assert client_id_pattern.match(ci.get_user_agent())
+
+    client_id_pattern = re.compile('test/\d+\.\d+\.\d+')
+    assert client_id_pattern.match(ci.get_user_agent('test'))


### PR DESCRIPTION
What this does:
- It adds a `User-Agent` header to requests with the format `carto-python-sdk/x.y.z` where `x.y.z` is the version number. E.g: `User-Agent: carto-python-sdk/1.3.0`. This replaces the default one, from `requests` library, which has the form `python-requests/x.y.z`.

- It adds a parameter `client` with the format `cps-X.Y.Z`. E.g: `client=cps-1.2.0`. It is modeled after CARTO.js `client` parameter.

Why we want this:
- The `User-Agent` header let us clearly identify all issued requests at nginx level. This is in general useful for debugging.
- The `client` parameter let us do things at the application level, such as issuing warnings for certain versions, plus it also allows for better debugging (think of a client bug in a given version).

As requested by @rochoa and hoping this helps in knowing better how our platform is used beyond COPY.

This is done on top of the COPY branch, just because it's a clean slate with respect to CI tests.