### PR TITLE
Example of CopySQLClient usage (low-level iterable interface)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ secret.py
 env
 
 .idea/*
+.vscode/
 .DS_Store
 *variables.sh

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,1 +1,2 @@
 files/copy_export.csv
+secret.conf

--- a/examples/copy_example.py
+++ b/examples/copy_example.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 
 
 # set input arguments
-parser = argparse.ArgumentParser(description='External database connector')
+parser = argparse.ArgumentParser(description='Example of CopySQLClient usage (file-based interface)')
 
 parser.add_argument('--base_url', type=str, dest='CARTO_BASE_URL',
                     default=os.environ.get('CARTO_API_URL', ''),

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -13,9 +13,6 @@ from carto.sql import CopySQLClient
 
 SECRET_CONFIG_FILE = 'secret.conf'
 
-# TODO pass format checker
-# TODO check with python3
-
 # Logger (better than print)
 logging.basicConfig(
     level=logging.INFO,
@@ -33,30 +30,40 @@ if os.path.isfile(SECRET_CONFIG_FILE):
     DST_URL = config.get('destination', 'carto_url')
     DST_API_KEY = config.get('destination', 'carto_api_key')
     if SRC_API_KEY == '' or DST_API_KEY == '':
-        logger.error("The configuration in %s does not look correct, please review it and re-run the script" % SECRET_CONFIG_FILE)
+        logger.error(
+            "The configuration in %s does not look correct,"
+            " please review it and re-run the script" % SECRET_CONFIG_FILE)
         sys.exit(1)
 else:
     logger.error("%s file does not exist. Generating..." % SECRET_CONFIG_FILE)
     with open(SECRET_CONFIG_FILE, 'w') as f:
         config.add_section('source')
-        config.set('source' , 'carto_url', 'https://source.carto.com/')
+        config.set('source', 'carto_url', 'https://source.carto.com/')
         config.set('source', 'carto_api_key', '')
         config.add_section('destination')
         config.set('destination', 'carto_url', 'https://dest.carto.com/')
         config.set('destination', 'carto_api_key', '')
         config.write(f)
-    logger.error("Generated %s. Please fill in the details of your source and destination CARTO accounts and re-run the script" % SECRET_CONFIG_FILE)
+    logger.error(
+        "Generated %s. Please fill in the details"
+        " of your source and destination CARTO accounts"
+        " and re-run the script" % SECRET_CONFIG_FILE)
     sys.exit(1)
 
 # Parse input argument(s)
 parser = argparse.ArgumentParser(description=(
     "Example of CopySQLClient usage (low-level iterable interface)."
-    " It uses the CopySQLClient to duplicate a table from a source CARTO account to a destination CARTO account."
+    " It uses the CopySQLClient to duplicate a table from a source CARTO"
+    " account to a destination CARTO account."
     " It works even across clouds and on-premise installations,"
-    " as long as there's connectivity and the API keys have suffient privileges."
+    " as long as there's connectivity and the API keys have"
+    " suffient privileges."
 ))
-parser.add_argument('-t', '--table', type=str, dest='TABLE_NAME', required=True,
-                    help='Name of the table to COPY from source to destination account')
+parser.add_argument(
+    '-t', '--table', type=str, dest='TABLE_NAME',
+    required=True,
+    help='Name of the table to COPY from source to destination account'
+)
 args = parser.parse_args()
 
 TABLE_NAME = args.TABLE_NAME
@@ -83,13 +90,17 @@ res = sql_src_client.send(query_generate_create_table_statement)
 logger.info('Response: {}'.format(res))
 
 # Get the table structure
-logger.info('Getting the CREATE TABLE statement for {}'.format(TABLE_NAME))
-query = "SELECT generate_create_table_statement('{}') AS create_table".format(TABLE_NAME)
+logger.info('Getting the CREATE TABLE statement for %s' % TABLE_NAME)
+query = (
+    "SELECT generate_create_table_statement('%s')"
+    " AS create_table" % TABLE_NAME
+)
 res = sql_src_client.send(query)
 create_table = res['rows'][0]['create_table']
 
-# This is a bit of a trick: we omit the sequences to avoid dependencies on other objects
-# Normally this just affects the cartodb_id and can optionally be fixed by cartodby'ing
+# This is a bit of a trick: we omit the sequences to avoid
+# dependencies on other objects Normally this just affects the
+# cartodb_id and can optionally be fixed by cartodby'ing
 create_table_no_seqs = re.sub(r'DEFAULT nextval\([^\)]+\)', ' ', create_table)
 logger.info(create_table_no_seqs)
 
@@ -100,7 +111,9 @@ logger.info('Response: {}'.format(res))
 
 # Cartodbfy the table (this is optional)
 logger.info("Cartodbfy'ing the destination table...")
-res = sql_dst_client.send("SELECT CDB_CartodbfyTable(current_schema, '{}')".format(TABLE_NAME))
+res = sql_dst_client.send(
+    "SELECT CDB_CartodbfyTable(current_schema, '%s')" % TABLE_NAME
+)
 logger.info('Response: {}'.format(res))
 
 # Create COPY clients
@@ -110,6 +123,6 @@ copy_dst_client = CopySQLClient(auth_dst_client)
 # COPY (streaming) the data from the source to the dest table
 # we use here all the COPY defaults
 logger.info("Streaming the data from source to destination...")
-response = copy_src_client.copyto('COPY {} TO STDOUT'.format(TABLE_NAME))
-result = copy_dst_client.copyfrom('COPY {} FROM STDIN'.format(TABLE_NAME), response)
+response = copy_src_client.copyto('COPY %s TO STDOUT' % TABLE_NAME)
+result = copy_dst_client.copyfrom('COPY %s FROM STDIN' % TABLE_NAME, response)
 logger.info('Result: {}'.format(result))

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -120,8 +120,10 @@ logger.info('Response: {}'.format(res))
 copy_src_client = CopySQLClient(auth_src_client)
 copy_dst_client = CopySQLClient(auth_dst_client)
 
-# COPY (streaming) the data from the source to the dest table
-# we use here all the COPY defaults
+# COPY (streaming) the data from the source to the dest table. We use
+# here all the COPY defaults. Note that we take the `response` from
+# the `copyto`, which can be iterated, and we pipe it directly into
+# the `copyfrom`.
 logger.info("Streaming the data from source to destination...")
 response = copy_src_client.copyto('COPY %s TO STDOUT' % TABLE_NAME)
 result = copy_dst_client.copyfrom('COPY %s FROM STDIN' % TABLE_NAME, response)

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -100,7 +100,7 @@ create_table = res['rows'][0]['create_table']
 
 # This is a bit of a trick: we omit the sequences to avoid
 # dependencies on other objects Normally this just affects the
-# cartodb_id and can optionally be fixed by cartodby'ing
+# cartodb_id and can optionally be fixed by cartodbfy'ing
 create_table_no_seqs = re.sub(r'DEFAULT nextval\([^\)]+\)', ' ', create_table)
 logger.info(create_table_no_seqs)
 

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -5,6 +5,7 @@ import re
 import os
 import sys
 import ConfigParser
+import argparse
 
 from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
@@ -48,8 +49,18 @@ else:
     logger.error("Generated %s. Please fill in the details of your source and destination CARTO accounts and re-run the script" % SECRET_CONFIG_FILE)
     sys.exit(1)
 
-# TODO add this as a command line argument
-TABLE_NAME = 'taxi_50k'
+# Parse input argument(s)
+parser = argparse.ArgumentParser(description=(
+    "Example of CopySQLClient usage (low-level iterable interface)."
+    " It uses the CopySQLClient to duplicate a table from a source CARTO account to a destination CARTO account."
+    " It works even across clouds and on-premise installations,"
+    " as long as there's connectivity and the API keys have suffient privileges."
+))
+parser.add_argument('-t', '--table', type=str, dest='TABLE_NAME', required=True,
+                    help='Name of the table to COPY from source to destination account')
+args = parser.parse_args()
+
+TABLE_NAME = args.TABLE_NAME
 
 # Set authentification to CARTO
 auth_src_client = APIKeyAuthClient(

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -4,7 +4,7 @@ import logging
 import re
 import os
 import sys
-import ConfigParser
+import configparser
 import argparse
 
 from carto.auth import APIKeyAuthClient
@@ -24,9 +24,9 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 # Configuration goes here
+config = configparser.ConfigParser()
 if os.path.isfile(SECRET_CONFIG_FILE):
     with open(SECRET_CONFIG_FILE, 'r') as f:
-        config = ConfigParser.ConfigParser()
         config.readfp(f)
     SRC_URL = config.get('source', 'carto_url')
     SRC_API_KEY = config.get('source', 'carto_api_key')
@@ -38,7 +38,6 @@ if os.path.isfile(SECRET_CONFIG_FILE):
 else:
     logger.error("%s file does not exist. Generating..." % SECRET_CONFIG_FILE)
     with open(SECRET_CONFIG_FILE, 'w') as f:
-        config = ConfigParser.ConfigParser()
         config.add_section('source')
         config.set('source' , 'carto_url', 'https://source.carto.com/')
         config.set('source', 'carto_api_key', '')

--- a/examples/duplicate_table.py
+++ b/examples/duplicate_table.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+
+import logging
+import re
+import os
+import sys
+import ConfigParser
+
+from carto.auth import APIKeyAuthClient
+from carto.sql import SQLClient
+from carto.sql import CopySQLClient
+
+SECRET_CONFIG_FILE = 'secret.conf'
+
+# TODO pass format checker
+# TODO check with python3
+
+# Logger (better than print)
+logging.basicConfig(
+    level=logging.INFO,
+    format=' %(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%I:%M:%S %p')
+logger = logging.getLogger()
+
+# Configuration goes here
+if os.path.isfile(SECRET_CONFIG_FILE):
+    with open(SECRET_CONFIG_FILE, 'r') as f:
+        config = ConfigParser.ConfigParser()
+        config.readfp(f)
+    SRC_URL = config.get('source', 'carto_url')
+    SRC_API_KEY = config.get('source', 'carto_api_key')
+    DST_URL = config.get('destination', 'carto_url')
+    DST_API_KEY = config.get('destination', 'carto_api_key')
+    if SRC_API_KEY == '' or DST_API_KEY == '':
+        logger.error("The configuration in %s does not look correct, please review it and re-run the script" % SECRET_CONFIG_FILE)
+        sys.exit(1)
+else:
+    logger.error("%s file does not exist. Generating..." % SECRET_CONFIG_FILE)
+    with open(SECRET_CONFIG_FILE, 'w') as f:
+        config = ConfigParser.ConfigParser()
+        config.add_section('source')
+        config.set('source' , 'carto_url', 'https://source.carto.com/')
+        config.set('source', 'carto_api_key', '')
+        config.add_section('destination')
+        config.set('destination', 'carto_url', 'https://dest.carto.com/')
+        config.set('destination', 'carto_api_key', '')
+        config.write(f)
+    logger.error("Generated %s. Please fill in the details of your source and destination CARTO accounts and re-run the script" % SECRET_CONFIG_FILE)
+    sys.exit(1)
+
+# TODO add this as a command line argument
+TABLE_NAME = 'taxi_50k'
+
+# Set authentification to CARTO
+auth_src_client = APIKeyAuthClient(
+    SRC_URL,
+    SRC_API_KEY
+)
+auth_dst_client = APIKeyAuthClient(
+    DST_URL,
+    DST_API_KEY
+)
+
+# Get SQL API clients
+sql_src_client = SQLClient(auth_src_client)
+sql_dst_client = SQLClient(auth_dst_client)
+
+# A SQL utility function to extract source table structure. See:
+# https://stackoverflow.com/questions/2593803/how-to-generate-the-create-table-sql-statement-for-an-existing-table-in-postgr
+# but we omit the schema name to be able to re-create it in another account.
+# TODO move this to an external file
+query_generate_create_table_statement = """
+CREATE OR REPLACE FUNCTION generate_create_table_statement(p_table_name varchar)
+  RETURNS text AS
+$BODY$
+DECLARE
+    v_table_ddl   text;
+    column_record record;
+BEGIN
+    FOR column_record IN
+        SELECT
+            b.relname as table_name,
+            a.attname as column_name,
+            pg_catalog.format_type(a.atttypid, a.atttypmod) as column_type,
+            CASE WHEN
+                (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+                 FROM pg_catalog.pg_attrdef d
+                 WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) IS NOT NULL THEN
+                'DEFAULT '|| (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+                              FROM pg_catalog.pg_attrdef d
+                              WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef)
+            ELSE
+                ''
+            END as column_default_value,
+            CASE WHEN a.attnotnull = true THEN
+                'NOT NULL'
+            ELSE
+                'NULL'
+            END as column_not_null,
+            a.attnum as attnum,
+            e.max_attnum as max_attnum
+        FROM
+            pg_catalog.pg_attribute a
+            INNER JOIN
+             (SELECT c.oid,
+                n.nspname,
+                c.relname
+              FROM pg_catalog.pg_class c
+                   LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+              WHERE c.relname ~ ('^('||p_table_name||')$')
+                AND pg_catalog.pg_table_is_visible(c.oid)
+              ORDER BY 2, 3) b
+            ON a.attrelid = b.oid
+            INNER JOIN
+             (SELECT
+                  a.attrelid,
+                  max(a.attnum) as max_attnum
+              FROM pg_catalog.pg_attribute a
+              WHERE a.attnum > 0
+                AND NOT a.attisdropped
+              GROUP BY a.attrelid) e
+            ON a.attrelid=e.attrelid
+        WHERE a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    LOOP
+        IF column_record.attnum = 1 THEN
+            v_table_ddl:='CREATE TABLE IF NOT EXISTS '||column_record.table_name||' (';
+        ELSE
+            v_table_ddl:=v_table_ddl||',';
+        END IF;
+
+        IF column_record.attnum <= column_record.max_attnum THEN
+            v_table_ddl:=v_table_ddl||chr(10)||
+                     '    '||column_record.column_name||' '||column_record.column_type||' '||column_record.column_default_value||' '||column_record.column_not_null;
+        END IF;
+    END LOOP;
+
+    v_table_ddl:=v_table_ddl||');';
+    RETURN v_table_ddl;
+END;
+$BODY$
+  LANGUAGE 'plpgsql' COST 100.0 SECURITY INVOKER;
+"""
+logger.info('Creating function generate_create_table_statement...')
+res = sql_src_client.send(query_generate_create_table_statement)
+logger.info('Response: {}'.format(res))
+
+# Get the table structure
+logger.info('Getting the CREATE TABLE statement for {}'.format(TABLE_NAME))
+query = "SELECT generate_create_table_statement('{}') AS create_table".format(TABLE_NAME)
+res = sql_src_client.send(query)
+create_table = res['rows'][0]['create_table']
+
+# This is a bit of a trick: we omit the sequences to avoid dependencies on other objects
+# Normally this just affects the cartodb_id and can optionally be fixed by cartodby'ing
+create_table_no_seqs = re.sub(r'DEFAULT nextval\([^\)]+\)', ' ', create_table)
+logger.info(create_table_no_seqs)
+
+# Create the table in the destination account
+logger.info('Creating the table in the destination account...')
+res = sql_dst_client.send(create_table_no_seqs)
+logger.info('Response: {}'.format(res))
+
+# Cartodbfy the table (this is optional)
+logger.info("Cartodbfy'ing the destination table...")
+res = sql_dst_client.send("SELECT CDB_CartodbfyTable(current_schema, '{}')".format(TABLE_NAME))
+logger.info('Response: {}'.format(res))
+
+# Create COPY clients
+copy_src_client = CopySQLClient(auth_src_client)
+copy_dst_client = CopySQLClient(auth_dst_client)
+
+# COPY the info from the source to the destination
+# we use here all the defaults
+logger.info("Streaming the data from source to destination...")
+response = copy_src_client.copyto('COPY {} TO STDOUT'.format(TABLE_NAME))
+result = copy_dst_client.copyfrom('COPY {} FROM STDIN'.format(TABLE_NAME), response)
+logger.info('Result: {}'.format(result))

--- a/examples/generate_create_table_statement.sql
+++ b/examples/generate_create_table_statement.sql
@@ -1,0 +1,74 @@
+-- A SQL utility function to extract source table structure.
+-- See # https://stackoverflow.com/questions/2593803/how-to-generate-the-create-table-sql-statement-for-an-existing-table-in-postgr
+-- We omit the schema name to be able to re-create it in another account.
+CREATE OR REPLACE FUNCTION generate_create_table_statement(p_table_name varchar)
+  RETURNS text AS
+$BODY$
+DECLARE
+    v_table_ddl   text;
+    column_record record;
+BEGIN
+    FOR column_record IN
+        SELECT
+            b.relname as table_name,
+            a.attname as column_name,
+            pg_catalog.format_type(a.atttypid, a.atttypmod) as column_type,
+            CASE WHEN
+                (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+                 FROM pg_catalog.pg_attrdef d
+                 WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) IS NOT NULL THEN
+                'DEFAULT '|| (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+                              FROM pg_catalog.pg_attrdef d
+                              WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef)
+            ELSE
+                ''
+            END as column_default_value,
+            CASE WHEN a.attnotnull = true THEN
+                'NOT NULL'
+            ELSE
+                'NULL'
+            END as column_not_null,
+            a.attnum as attnum,
+            e.max_attnum as max_attnum
+        FROM
+            pg_catalog.pg_attribute a
+            INNER JOIN
+             (SELECT c.oid,
+                n.nspname,
+                c.relname
+              FROM pg_catalog.pg_class c
+                   LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+              WHERE c.relname ~ ('^('||p_table_name||')$')
+                AND pg_catalog.pg_table_is_visible(c.oid)
+              ORDER BY 2, 3) b
+            ON a.attrelid = b.oid
+            INNER JOIN
+             (SELECT
+                  a.attrelid,
+                  max(a.attnum) as max_attnum
+              FROM pg_catalog.pg_attribute a
+              WHERE a.attnum > 0
+                AND NOT a.attisdropped
+              GROUP BY a.attrelid) e
+            ON a.attrelid=e.attrelid
+        WHERE a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    LOOP
+        IF column_record.attnum = 1 THEN
+            v_table_ddl:='CREATE TABLE IF NOT EXISTS '||column_record.table_name||' (';
+        ELSE
+            v_table_ddl:=v_table_ddl||',';
+        END IF;
+
+        IF column_record.attnum <= column_record.max_attnum THEN
+            v_table_ddl:=v_table_ddl||chr(10)||
+                     '    '||column_record.column_name||' '||column_record.column_type||' '||column_record.column_default_value||' '||column_record.column_not_null;
+        END IF;
+    END LOOP;
+
+    v_table_ddl:=v_table_ddl||');';
+    RETURN v_table_ddl;
+END;
+$BODY$
+  LANGUAGE 'plpgsql' COST 100.0 SECURITY INVOKER;

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.7.0
 pyrestcli>=0.6.4
+configparser>=3.5.0
 ../
 prettytable


### PR DESCRIPTION
This does not adds code to the library but an example (hopefully a better one) of how to use the `CopySQLClient` to actually stream data.

I tried to make it both instructive and useful.

Example usage:
```
$ python duplicate_table.py 
 01:10:24 PM - ERROR - secret.conf file does not exist. Generating...
 01:10:24 PM - ERROR - Generated secret.conf. Please fill in the details of your source and destination CARTO accounts and re-run the script
```

then after filling in the `secret.conf`:

```
$ python duplicate_table.py 
usage: duplicate_table.py [-h] -t TABLE_NAME
duplicate_table.py: error: the following arguments are required: -t/--table

$ python duplicate_table.py -h
usage: duplicate_table.py [-h] -t TABLE_NAME

Example of CopySQLClient usage (low-level iterable interface). It uses the
CopySQLClient to duplicate a table from a source CARTO account to a
destination CARTO account. It works even across clouds and on-premise
installations, as long as there's connectivity and the API keys have suffient
privileges.

optional arguments:
  -h, --help            show this help message and exit
  -t TABLE_NAME, --table TABLE_NAME
                        Name of the table to COPY from source to destination
                        account
```

and the real execution of it:
```
$ python duplicate_table.py -t busstops_losangeles                                                                                                                                                               
 01:17:48 PM - INFO - Creating function generate_create_table_statement...
 01:17:49 PM - INFO - Response: {'total_rows': 0, 'fields': {}, 'time': 0.015, 'rows': []}
 01:17:49 PM - INFO - Getting the CREATE TABLE statement for busstops_losangeles
 01:17:51 PM - INFO - CREATE TABLE IF NOT EXISTS busstops_losangeles (
    cartodb_id integer   NOT NULL,
    the_geom geometry(Geometry,4326)  NULL,
    the_geom_webmercator geometry(Geometry,3857)  NULL,
    along text  NULL,
    at text  NULL,
    long double precision  NULL,
    lat double precision  NULL,
    linedir01 text  NULL,
    linedir02 text  NULL,
    linedir03 text  NULL,
    linedir04 text  NULL,
    linedir05 text  NULL,
    linedir06 text  NULL,
    linedir07 text  NULL,
    linedir08 text  NULL,
    linedir09 text  NULL,
    stopnum integer  NULL,
    linedir11 text  NULL,
    linedir12 text  NULL,
    linedir13 text  NULL,
    linedir14 text  NULL,
    linedir15 text  NULL,
    linedir16 text  NULL,
    linedir17 text  NULL,
    linedir18 text  NULL,
    linedir19 text  NULL,
    linedir20 text  NULL,
    created_at date  NULL,
    updated_at date  NULL,
    linedir10 text  NULL);
 01:17:51 PM - INFO - Creating the table in the destination account...
 01:17:52 PM - INFO - Response: {'total_rows': 0, 'fields': {}, 'time': 0.09, 'rows': []}
 01:17:52 PM - INFO - Cartodbfy'ing the destination table...
 01:17:52 PM - INFO - Response: {'total_rows': 1, 'fields': {'cdb_cartodbfytable': {'type': 'regclass'}}, 'time': 0.091, 'rows': [{'cdb_cartodbfytable': 'busstops_losangeles'}], 'notices': ['trigger "track_updates" for relation "busstops_losangeles" does not exist, skipping', 'trigger "update_the_geom_webmercator_trigger" for relation "busstops_losangeles" does not exist, skipping', 'trigger "test_quota" for relation "busstops_losangeles" does not exist, skipping', 'trigger "test_quota_per_row" for relation "busstops_losangeles" does not exist, skipping']}
 01:17:52 PM - INFO - Streaming the data from source to destination...
 01:17:57 PM - INFO - Result: {'total_rows': 14777, 'time': 4.1}
```