### PR TITLE
Fix cancel race condition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+MMM-DD-2018: version 1.3.x
+ - BatchSQLClient.cancel is now resilient to 'Cannot set status from done to cancelled' errors
+ - Fixed a race condition in BatchSQLClient tests
+
 Aug-10-2018: version 1.3.0
  - Added a `CopySQLClient` for efficient streaming of data to and from CARTO (#87)
  - Fixed CI tests

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -241,7 +241,13 @@ class BatchSQLClient(object):
 
         :raise CartoException:
         """
-        confirmation = self.send(self.api_url + job_id, http_method="DELETE")
+        try:
+            confirmation = self.send(self.api_url + job_id, http_method="DELETE")
+        except CartoException as e:
+            if 'Cannot set status from done to cancelled' in e.args[0].args[0]:
+                return 'done'
+            else:
+                raise e
         return confirmation['status']
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import time
 
 from carto.exceptions import CartoException
 from carto.sql import SQLClient, BatchSQLClient
@@ -56,22 +57,26 @@ def test_no_auth_sql_error_get(no_auth_client):
         sql.send('select * from non_existing_dataset', {'do_post': False})
 
 
+def cancel_job_if_not_finished(batch_sql_client, job_id):
+    status = batch_sql_client.cancel(job_id)
+    attempts = 1
+    while status != 'done' and status != 'cancelled' and attempts < 3:
+        time.sleep(1)
+        status = batch_sql_client.cancel(job_id)
+        attempts += 1
+    assert status == 'done' or status == 'cancelled'
+
 def test_batch_create(api_key_auth_client_usr):
     sql = BatchSQLClient(api_key_auth_client_usr)
 
     # Create query
     data = sql.create(BATCH_SQL_SINGLE_QUERY)
 
-    # Update status
+    # Get job ID
     job_id = data['job_id']
 
     # Cancel if not finished
-    try:
-        confirmation = sql.cancel(job_id)
-    except CartoException:
-        pass
-    else:
-        assert confirmation == 'cancelled'
+    cancel_job_if_not_finished(sql, job_id)
 
 
 @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
@@ -82,16 +87,11 @@ def test_batch_multi_sql(api_key_auth_client_usr):
     # Create query
     data = sql.create(BATCH_SQL_MULTI_QUERY)
 
-    # Update status
+    # Get job ID
     job_id = data['job_id']
 
     # Cancel if not finished
-    try:
-        confirmation = sql.cancel(job_id)
-    except CartoException:
-        pass
-    else:
-        assert confirmation == 'cancelled'
+    cancel_job_if_not_finished(sql, job_id)
 
 
 def test_sql_unverified(non_verified_auth_client):


### PR DESCRIPTION
As stated in the NEWS, this PR does 2 things:
 - BatchSQLClient.cancel is now resilient to 'Cannot set status from done to cancelled' errors
 - Fixed a race condition in BatchSQLClient tests

I did this because I was a bit fed up of a couple tests failing randomly:
```
    def test_batch_create(api_key_auth_client_usr):
        sql = BatchSQLClient(api_key_auth_client_usr)
    
        # Create query
        data = sql.create(BATCH_SQL_SINGLE_QUERY)
    
        # Update status
        job_id = data['job_id']
    
        # Cancel if not finished
        try:
            confirmation = sql.cancel(job_id)
        except CartoException:
            pass
        else:
>           assert confirmation == 'cancelled'
E           AssertionError: assert 'running' == 'cancelled'
E             - running
E             + cancelled
```
https://travis-ci.org/CartoDB/carto-python/jobs/418121501
https://travis-ci.org/CartoDB/carto-python/jobs/418210293
https://travis-ci.org/CartoDB/carto-python/jobs/418210297
