### PR TITLE
Include synchronization data in the dataset model

### DIFF
--- a/carto/datasets.py
+++ b/carto/datasets.py
@@ -23,7 +23,7 @@ from .file_import import FileImportJobManager
 from .resources import WarnResource
 from .sync_tables import SyncTableJobManager
 from .tables import TableManager
-from .fields import TableField, UserField, PermissionField
+from .fields import TableField, UserField, PermissionField, SynchronizationField
 from .paginators import CartoPaginator
 from .resources import Manager
 
@@ -67,7 +67,7 @@ class Dataset(WarnResource):
     privacy = CharField()
     source = None
     stats = DateTimeField(many=True)
-    synchronization = None
+    synchronization = SynchronizationField()
     table = TableField()
     tags = CharField(many=True)
     title = CharField()

--- a/carto/fields.py
+++ b/carto/fields.py
@@ -47,3 +47,9 @@ class PermissionField(ResourceField):
     :class:`carto.permissions.Permission`
     """
     value_class = "carto.permissions.Permission"
+
+class SynchronizationField(ResourceField):
+    """
+    :class:`carto.synchronizations.Synchronization`
+    """
+    value_class = "carto.synchronizations.Synchronization"

--- a/carto/synchronizations.py
+++ b/carto/synchronizations.py
@@ -1,0 +1,46 @@
+"""
+Entity classes for defining synchronizations
+
+.. module:: carto.synchronizations
+   :platform: Unix, Windows
+   :synopsis: Entity classes for defining synchronizations
+
+.. moduleauthor:: Daniel Carrion <daniel@carto.com>
+.. moduleauthor:: Alberto Romeu <alrocar@carto.com>
+
+
+"""
+
+from pyrestcli.resources import Resource
+from pyrestcli.fields import CharField, DateTimeField, BooleanField, IntegerField
+
+
+class Synchronization(Resource):
+    """
+    Represents a synchronization in CARTO. This is an internal data type, with no
+    specific API endpoints
+    """
+    checksum = CharField()
+    created_at = DateTimeField()
+    error_code = CharField()
+    error_message = CharField()
+    id = CharField()
+    interval = IntegerField()
+    modified_at = DateTimeField()
+    name = CharField()
+    ran_at = DateTimeField()
+    retried_times = IntegerField()
+    run_at = DateTimeField()
+    service_item_id = CharField()
+    service_name = CharField()
+    state = CharField()
+    updated_at = DateTimeField()
+    url = CharField()
+    user_id = CharField()
+    content_guessing = BooleanField()
+    etag = CharField()
+    log_id = BooleanField()
+    quoted_fields_guessing = BooleanField()
+    type_guessing = BooleanField()
+    from_external_source = BooleanField()
+    visualization_id = BooleanField()

--- a/carto/visualizations.py
+++ b/carto/visualizations.py
@@ -18,7 +18,7 @@ from pyrestcli.fields import IntegerField, CharField, DateTimeField, \
     BooleanField
 
 from .exceptions import CartoException
-from .fields import TableField
+from .fields import TableField, SynchronizationField
 from .resources import Manager, WarnResource
 from .paginators import CartoPaginator
 from .export import ExportJob
@@ -60,7 +60,7 @@ class Visualization(WarnResource):
     privacy = None
     source = None
     stats = None
-    synchronization = None
+    synchronization = SynchronizationField()
     table = TableField()
     related_tables = TableField(many=True)
     tags = None


### PR DESCRIPTION
Related https://github.com/CartoDB/carto-python/issues/96

Sometimes we want to know if a datasets come is synchronized so we
need to add that information when we ask for the dataset/s