### PR TITLE
adds option for passing custom client id

### DIFF
--- a/carto/auth.py
+++ b/carto/auth.py
@@ -89,7 +89,8 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
     You can find your API key by clicking on the API key section of the user
     dropdown menu
     """
-    def __init__(self, base_url, api_key, organization=None, session=None):
+    def __init__(self, base_url, api_key, organization=None, session=None,
+                 client_id=None):
         """
         Init method
 
@@ -98,8 +99,10 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
         :param api_key: API key
         :param organization: For enterprise users, organization user belongs to
         :param session: requests' session object
+        :param client_id: Client param string to pass for request args
         :type api_key: str
         :type organization: str
+        :type client_id: str
 
         :return:
         """
@@ -108,7 +111,10 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
         base_url = self.check_base_url(base_url)
         self.username = self.get_user_name(base_url)
         self.user_agent = self.get_user_agent()
-        self.client_id = self.get_client_identifier()
+        if client_id is None:
+            self.client_id = self.get_client_identifier()
+        else:
+            self.client_id = client_id
 
         super(APIKeyAuthClient, self).__init__(base_url, session=session)
 


### PR DESCRIPTION
I'm not sure if this is the best approach, but it seems like a simple way to allow cartoframes (or any other application) to set the client arg. I'm starting to wonder, though, if there should be a different request param that should be set in cartoframes' case, like `super_client=cartoframes_v0.8.1` so as not to quash all carto python sdk usage in the logs.


cc @alrocar 