### PR TITLE
Raise exception when trying to delete dataset with dependent viz

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ xxx-xx-2019: version 1.5.0
  - Adds a copyto_stream method in sql (#103)
  - Adds wait for completion for batch jobs (#104)
  - Improve rate limit exception (#108)
+ - Raise exception when trying to delete dataset with dependent viz (#107)
 
 Nov-29-2018: version 1.4.0
  - Adds a custom client_id argument for authentication that optionally overwrites the default (#99)

--- a/carto/datasets.py
+++ b/carto/datasets.py
@@ -23,7 +23,8 @@ from .file_import import FileImportJobManager
 from .resources import WarnResource
 from .sync_tables import SyncTableJobManager
 from .tables import TableManager
-from .fields import TableField, UserField, PermissionField, SynchronizationField, VisualizationField
+from .fields import (TableField, UserField, PermissionField,
+                     SynchronizationField, VisualizationField)
 from .paginators import CartoPaginator
 from .resources import Manager
 
@@ -82,8 +83,10 @@ class Dataset(WarnResource):
 
     def delete(self):
         if self.dependent_visualizations_count > 0:
-            raise CartoException(_('This dataset contains dependent visualizations. ' +
-                                   'Delete them to be able to delete this dataset.'))
+            raise CartoException(_(
+                'This dataset contains dependent visualizations. ' +
+                'Delete them to be able to delete this dataset.')
+            )
 
         super(WarnResource, self).delete()
 

--- a/carto/datasets.py
+++ b/carto/datasets.py
@@ -81,8 +81,8 @@ class Dataset(WarnResource):
     uses_builder_features = BooleanField()
     user = UserField()
 
-    def delete(self):
-        if self.dependent_visualizations_count > 0:
+    def delete(self, force=False):
+        if force is not False and self.dependent_visualizations_count > 0:
             raise CartoException(_(
                 'This dataset contains dependent visualizations. ' +
                 'Delete them to be able to delete this dataset.')

--- a/carto/datasets.py
+++ b/carto/datasets.py
@@ -81,13 +81,17 @@ class Dataset(WarnResource):
     uses_builder_features = BooleanField()
     user = UserField()
 
-    def delete(self, force=False):
-        if force is not False and self.dependent_visualizations_count > 0:
+    def delete(self):
+        if self.dependent_visualizations_count > 0:
             raise CartoException(_(
                 'This dataset contains dependent visualizations. ' +
-                'Delete them to be able to delete this dataset.')
+                'Delete them to be able to delete this dataset or use `force_delete` ' +
+                'to delete the dataset and the dependent visualizations.')
             )
 
+        super(WarnResource, self).delete()
+
+    def force_delete(self):
         super(WarnResource, self).delete()
 
     class Meta:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -121,7 +121,7 @@ def test_try_to_delete_dataset_with_dependent_visualizations(dataset_manager):
     dataset.delete()
 
 
-def test_try_to_force_delete_dataset_with_dependent_visualizations(dataset_manager):
+def test_force_delete_dataset_with_dependent_visualizations(dataset_manager):
     """
     Test trying to delete a dataset with dependent visualizations
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -121,6 +121,19 @@ def test_try_to_delete_dataset_with_dependent_visualizations(dataset_manager):
     dataset.delete()
 
 
+def test_try_to_force_delete_dataset_with_dependent_visualizations(dataset_manager):
+    """
+    Test trying to delete a dataset with dependent visualizations
+
+    :param dataset_manager: Dataset manager to work with
+    """
+    dataset = dataset_manager.create(IMPORT_URL)
+
+    dataset.dependent_visualizations_count = 1
+
+    dataset.delete(force=True)
+
+
 def test_import_from_object(dataset_manager):
     """
     Imports a file as an object

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -103,14 +103,14 @@ def test_create_and_modify_and_delete_dataset_as_sync_table(dataset_manager):
     with pytest.raises(NotFoundException):
         dataset_manager.get(dataset_id)
 
-def test_create_and_try_to_delete_dataset_with_dependent_visualizations(dataset_manager):
+
+def test_try_to_delete_dataset_with_dependent_visualizations(dataset_manager):
     """
     Test trying to delete a dataset with dependent visualizations
 
     :param dataset_manager: Dataset manager to work with
     """
     dataset = dataset_manager.create(IMPORT_URL)
-    dataset_id = dataset.get_id()
 
     dataset.dependent_visualizations_count = 1
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -131,7 +131,7 @@ def test_force_delete_dataset_with_dependent_visualizations(dataset_manager):
 
     dataset.dependent_visualizations_count = 1
 
-    dataset.delete(force=True)
+    dataset.force_delete()
 
 
 def test_import_from_object(dataset_manager):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ from pyrestcli.exceptions import NotFoundException
 
 from carto.datasets import DatasetManager
 from carto.permissions import PRIVATE, PUBLIC
+from carto.exceptions import CartoException
 
 from secret import IMPORT_URL, IMPORT_FILE
 
@@ -101,6 +102,23 @@ def test_create_and_modify_and_delete_dataset_as_sync_table(dataset_manager):
     dataset.delete()
     with pytest.raises(NotFoundException):
         dataset_manager.get(dataset_id)
+
+def test_create_and_try_to_delete_dataset_with_dependent_visualizations(dataset_manager):
+    """
+    Test trying to delete a dataset with dependent visualizations
+
+    :param dataset_manager: Dataset manager to work with
+    """
+    dataset = dataset_manager.create(IMPORT_URL)
+    dataset_id = dataset.get_id()
+
+    dataset.dependent_visualizations_count = 1
+
+    with pytest.raises(CartoException):
+        dataset.delete()
+
+    dataset.dependent_visualizations_count = 0
+    dataset.delete()
 
 
 def test_import_from_object(dataset_manager):


### PR DESCRIPTION
This PR adds feature to raise `CartoException` when trying to delete a dataset that has dependent visualizations.

It needs a joint PR to be merged in order to have `dependent_visualizations` and `dependent_visualizations_count` when retrieving a dataset using `GET` method through API.

`with_dependent_visualizations` parameter has been added to all requests to `viz` endpoint in order to receive `dependent_visualizations` and `dependent_visualizations_count` within response data.