### PR TITLE
Improve rate limit exception

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 xxx-xx-2019: version 1.5.0
  - max line length from 80 to 120
+ - Improve rate limit exception (#108)
 
 Nov-29-2018: version 1.4.0
  - Adds a custom client_id argument for authentication that optionally overwrites the default (#99)

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -117,7 +117,7 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
 
         super(APIKeyAuthClient, self).__init__(base_url, session=session)
 
-    def send(self, relative_path, http_method, *args, **requests_args):
+    def send(self, relative_path, http_method, **requests_args):
         """
         Makes an API-key-authorized request
 

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -140,7 +140,7 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
         except Exception as e:
             raise CartoException(e)
 
-        if CartoRateLimitException.isResponseRateLimited(response):
+        if CartoRateLimitException.isRateLimited(response):
             raise CartoRateLimitException(response)
 
         return response
@@ -208,11 +208,14 @@ class NonVerifiedAPIKeyAuthClient(APIKeyAuthClient):
         try:
             http_method, requests_args = self.prepare_send(http_method, **requests_args)
             requests_args["verify"] = False
-            return super(APIKeyAuthClient, self).send(relative_path,
-                                                      http_method,
-                                                      **requests_args)
+            response = super(APIKeyAuthClient, self).send(relative_path, http_method, **requests_args)
         except Exception as e:
             raise CartoException(e)
+
+        if CartoRateLimitException.isRateLimited(response):
+            raise CartoRateLimitException(response)
+
+        return response
 
 
 class AuthAPIClient(_UsernameGetter, _BaseUrlChecker, BasicAuthClient):

--- a/carto/auth.py
+++ b/carto/auth.py
@@ -140,7 +140,7 @@ class APIKeyAuthClient(_UsernameGetter, _BaseUrlChecker, _ClientIdentifier,
         except Exception as e:
             raise CartoException(e)
 
-        if CartoRateLimitException.isRateLimited(response):
+        if CartoRateLimitException.is_rate_limited(response):
             raise CartoRateLimitException(response)
 
         return response
@@ -212,7 +212,7 @@ class NonVerifiedAPIKeyAuthClient(APIKeyAuthClient):
         except Exception as e:
             raise CartoException(e)
 
-        if CartoRateLimitException.isRateLimited(response):
+        if CartoRateLimitException.is_rate_limited(response):
             raise CartoRateLimitException(response)
 
         return response

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -17,3 +17,21 @@ class CartoException(Exception):
     Any Exception produced by carto-python should be wrapped around this class
     """
     pass
+
+
+class CartoRateLimitException(CartoException):
+    def __init__(self, exception, response):
+        super()
+        self.limit = response.headers['Carto-Rate-Limit-Limit']
+        self.remaining = response.headers['Carto-Rate-Limit-Remaining']
+        self.retryAfter = response.headers['Retry-After']
+        self.reset = response.headers['Carto-Rate-Limit-Reset']
+
+    @staticmethod
+    def isResponseRateLimited(response):
+        if (response.status_code == 429 and
+            'Retry-After' in response.headers and
+            int(response.headers['Retry-After']) >= 0):
+            return True
+
+        return False

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -21,7 +21,7 @@ class CartoException(Exception):
 
 class CartoRateLimitException(CartoException):
     def __init__(self, response):
-        super()
+        super().__init__(response.text)
         self.limit = int(response.headers['Carto-Rate-Limit-Limit'])
         self.remaining = int(response.headers['Carto-Rate-Limit-Remaining'])
         self.retryAfter = int(response.headers['Retry-After'])

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -10,7 +10,7 @@ Module for carto-python exceptions definitions
 
 
 """
-
+from requests import codes
 
 class CartoException(Exception):
     """
@@ -20,7 +20,7 @@ class CartoException(Exception):
 
 
 class CartoRateLimitException(CartoException):
-    def __init__(self, exception, response):
+    def __init__(self, response):
         super()
         self.limit = response.headers['Carto-Rate-Limit-Limit']
         self.remaining = response.headers['Carto-Rate-Limit-Remaining']
@@ -29,7 +29,7 @@ class CartoRateLimitException(CartoException):
 
     @staticmethod
     def isResponseRateLimited(response):
-        if (response.status_code == 429 and 'Retry-After' in response.headers and
+        if (response.status_code == codes.too_many_requests and 'Retry-After' in response.headers and
                 int(response.headers['Retry-After']) >= 0):
             return True
 

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -22,15 +22,15 @@ class CartoException(Exception):
 class CartoRateLimitException(CartoException):
     def __init__(self, response):
         super()
-        self.limit = response.headers['Carto-Rate-Limit-Limit']
-        self.remaining = response.headers['Carto-Rate-Limit-Remaining']
-        self.retryAfter = response.headers['Retry-After']
-        self.reset = response.headers['Carto-Rate-Limit-Reset']
+        self.limit = int(response.headers['Carto-Rate-Limit-Limit'])
+        self.remaining = int(response.headers['Carto-Rate-Limit-Remaining'])
+        self.retryAfter = int(response.headers['Retry-After'])
+        self.reset = int(response.headers['Carto-Rate-Limit-Reset'])
 
     @staticmethod
     def isResponseRateLimited(response):
         if (response.status_code == codes.too_many_requests and 'Retry-After' in response.headers and
-                int(response.headers['Retry-After']) >= 0):
+                response.headers['Retry-After']) >= 0:
             return True
 
         return False

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -24,11 +24,11 @@ class CartoRateLimitException(CartoException):
         super().__init__(response.text)
         self.limit = int(response.headers['Carto-Rate-Limit-Limit'])
         self.remaining = int(response.headers['Carto-Rate-Limit-Remaining'])
-        self.retryAfter = int(response.headers['Retry-After'])
+        self.retry_after = int(response.headers['Retry-After'])
         self.reset = int(response.headers['Carto-Rate-Limit-Reset'])
 
     @staticmethod
-    def isResponseRateLimited(response):
+    def isRateLimited(response):
         if (response.status_code == codes.too_many_requests and 'Retry-After' in response.headers and
                 int(response.headers['Retry-After']) >= 0):
             return True

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -43,7 +43,7 @@ class CartoRateLimitException(CartoException):
         self.reset = int(response.headers['Carto-Rate-Limit-Reset'])
 
     @staticmethod
-    def isRateLimited(response):
+    def is_rate_limited(response):
         """
         Checks if the response has been rate limited by CARTO APIs
 

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -29,9 +29,8 @@ class CartoRateLimitException(CartoException):
 
     @staticmethod
     def isResponseRateLimited(response):
-        if (response.status_code == 429 and
-            'Retry-After' in response.headers and
-            int(response.headers['Retry-After']) >= 0):
+        if (response.status_code == 429 and 'Retry-After' in response.headers and
+                int(response.headers['Retry-After']) >= 0):
             return True
 
         return False

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -20,7 +20,22 @@ class CartoException(Exception):
 
 
 class CartoRateLimitException(CartoException):
+    """
+    This exception is raised when a request is rate limited by SQL or Maps APIs (429 Too Many Requests HTTP error).
+    More info about CARTO rate limits: https://carto.com/developers/fundamentals/limits/#rate-limits
+
+    It extends CartoException with the rate limits info, so that any client can manage
+    when to retry a rate limited request.
+    """
     def __init__(self, response):
+        """
+        Init method
+
+        :param response: The response rate limited by CARTO APIs
+        :type response: requests.models.Response class
+
+        :return:
+        """
         super().__init__(response.text)
         self.limit = int(response.headers['Carto-Rate-Limit-Limit'])
         self.remaining = int(response.headers['Carto-Rate-Limit-Remaining'])
@@ -29,6 +44,14 @@ class CartoRateLimitException(CartoException):
 
     @staticmethod
     def isRateLimited(response):
+        """
+        Checks if the response has been rate limited by CARTO APIs
+
+        :param response: The response rate limited by CARTO APIs
+        :type response: requests.models.Response class
+
+        :return: Boolean
+        """
         if (response.status_code == codes.too_many_requests and 'Retry-After' in response.headers and
                 int(response.headers['Retry-After']) >= 0):
             return True

--- a/carto/exceptions.py
+++ b/carto/exceptions.py
@@ -30,7 +30,7 @@ class CartoRateLimitException(CartoException):
     @staticmethod
     def isResponseRateLimited(response):
         if (response.status_code == codes.too_many_requests and 'Retry-After' in response.headers and
-                response.headers['Retry-After']) >= 0:
+                int(response.headers['Retry-After']) >= 0):
             return True
 
         return False

--- a/carto/maps.py
+++ b/carto/maps.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from pyrestcli.resources import Manager, Resource
 
-from .exceptions import CartoException
+from .exceptions import CartoException, CartoRateLimitException
 
 API_VERSION = "v1"
 NAMED_API_ENDPOINT = "api/{api_version}/map/named/"
@@ -157,6 +157,8 @@ class NamedMap(BaseMap):
                     format(auth_token=auth)
 
             self.send(endpoint, "POST", json=params)
+        except CartoRateLimitException as e:
+            raise e
         except Exception as e:
             raise CartoException(e)
 
@@ -198,6 +200,8 @@ class AnonymousMap(BaseMap):
         """
         try:
             self.send(self.Meta.collection_endpoint, "POST", json=params)
+        except CartoRateLimitException as e:
+            raise e
         except Exception as e:
             raise CartoException(e)
 

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -14,7 +14,7 @@ Module for the SQL API
 import zlib
 import struct
 
-from .exceptions import CartoException
+from .exceptions import CartoException, CartoRateLimitException
 from requests import HTTPError
 
 SQL_API_URL = 'api/{api_version}/sql'
@@ -307,7 +307,7 @@ class CopySQLClient(object):
         :return: Response data as json
         :rtype: str
 
-        :raise CartoException:
+        :raise CartoException or CartoRateLimitException:
         """
         url = self.api_url + '/copyfrom'
         headers = {
@@ -331,6 +331,8 @@ class CopySQLClient(object):
                                         headers=headers,
                                         stream=True)
             response_json = self.client.get_response_data(response)
+        except CartoRateLimitException as e:
+            raise e
         except Exception as e:
             raise CartoException(e)
 
@@ -391,7 +393,7 @@ class CopySQLClient(object):
         :return: response object
         :rtype: Response
 
-        :raise CartoException:
+        :raise CartoException or CartoRateLimitException:
         """
         url = self.api_url + '/copyto'
         params = {'api_key': self.api_key, 'q': query}
@@ -402,6 +404,8 @@ class CopySQLClient(object):
                                         params=params,
                                         stream=True)
             response.raise_for_status()
+        except CartoRateLimitException as e:
+            raise e
         except HTTPError as e:
             if 400 <= response.status_code < 500:
                 # Client error, provide better reason

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -99,6 +99,8 @@ class SQLClient(object):
                 resp = self.auth_client.send(self.api_url, 'POST', data=params)
 
             return self.auth_client.get_response_data(resp, parse_json)
+        except CartoRateLimitException as e:
+            raise e
         except Exception as e:
             raise CartoException(e)
 
@@ -162,6 +164,8 @@ class BatchSQLClient(object):
                                     headers=http_header,
                                     json=json_body)
             data_json = self.client.get_response_data(data)
+        except CartoRateLimitException as e:
+            raise e
         except Exception as e:
             raise CartoException(e)
         return data_json
@@ -307,7 +311,7 @@ class CopySQLClient(object):
         :return: Response data as json
         :rtype: str
 
-        :raise CartoException or CartoRateLimitException:
+        :raise CartoException:
         """
         url = self.api_url + '/copyfrom'
         headers = {
@@ -393,7 +397,7 @@ class CopySQLClient(object):
         :return: response object
         :rtype: Response
 
-        :raise CartoException or CartoRateLimitException:
+        :raise CartoException:
         """
         url = self.api_url + '/copyto'
         params = {'api_key': self.api_key, 'q': query}

--- a/doc/source/general_concepts.rst
+++ b/doc/source/general_concepts.rst
@@ -150,10 +150,11 @@ The CARTO Python client provides additional instances of `ResourceField`:
 Exceptions
 ----------
 
-All the Exceptions of the CARTO Python client are wrapped into the `CartoException` class.
+- `CartoException`: Generic exception class of the CARTO Python client. Most of the exceptions are wrapped into it.
+- `CartoRateLimitException`: it is raised when a request is rate limited by SQL or Maps APIs (429 Too Many Requests HTTP error). `More info about CARTO rate limits`_. It extends `CartoException` class with the rate limits info, so that any client can manage when to retry a rate limited request.
 
-Please refer to the `CARTO API docs`_ for more information about concrete error codes and exceptions.
 
-.. _CARTO API docs: https://carto.com/docs/carto-engine/import-api/import-errors
+Please refer to the `CARTO developer center`_ for more information about concrete error codes and exceptions.
 
-.. _installation:
+.. _CARTO developer center: https://carto.com/developers
+.. _More info about CARTO rate limits: https://carto.com/developers/fundamentals/limits/#rate-limits


### PR DESCRIPTION
A part of https://github.com/CartoDB/cartoframes/issues/562

We want to add the related data (the HTTP headers: 'Carto-Rate-Limit-Limit', 'Carto-Rate-Limit-Remaining', 'Retry-After', 'Carto-Rate-Limit-Reset') to the exception fired when a request to Maps/SQL API is rate limited.
