### PR TITLE
Allow POST in copy to 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+xxx-xx-2019: version 1.6.1
+ - Allow POST in copy to (#142)
+
 Jun-17-2019: version 1.6.0
  - Auth API (#94)
  - Kuviz API (#121 #124)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 xxx-xx-2019: version 1.6.1
- - Allow POST in copy to (#142)
+ - Using POST in copy to if the query in longer than 1024 bytes (#142)
 
 Jun-17-2019: version 1.6.0
  - Auth API (#94)

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -298,6 +298,9 @@ class BatchSQLClient(object):
         return confirmation['status']
 
 
+COPY_TO_HTTP_METHODS = ['GET', 'POST']
+
+
 class CopySQLClient(object):
     """
     Allows to use the PostgreSQL COPY command for efficient streaming
@@ -446,6 +449,11 @@ class CopySQLClient(object):
 
         :raise CartoException:
         """
+        if not http_method or not isinstance(http_method, str) or http_method.upper() not in COPY_TO_HTTP_METHODS:
+            raise CartoException('`http_method` parameter is {i} and the allowed values can be: {v}'.format(
+                i=http_method,
+                v=', '.join(COPY_TO_HTTP_METHODS)))
+
         url = self.api_url + '/copyto'
         params = {'api_key': self.api_key, 'q': query}
 

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -441,7 +441,7 @@ class CopySQLClient(object):
         :type query: str
 
         :param http_method: HTTP method used in COPY TO request. Options:
-                            'GET' or 'POST'. Default value is False
+                            'GET' or 'POST'. Default value is 'GET'
         :type http_method: str
 
         :return: response object

--- a/carto/sql.py
+++ b/carto/sql.py
@@ -429,13 +429,17 @@ class CopySQLClient(object):
                                                compression_level)
         return result
 
-    def copyto(self, query):
+    def copyto(self, query, http_method='GET'):
         """
         Gets data from a table into a Response object that can be iterated
 
         :param query: The "COPY { table_name [(column_name[, ...])] | (query) }
                            TO STDOUT [WITH(option[,...])]" query to execute
         :type query: str
+
+        :param http_method: HTTP method used in COPY TO request. Options:
+                            'GET' or 'POST'. Default value is False
+        :type http_method: str
 
         :return: response object
         :rtype: Response
@@ -447,7 +451,7 @@ class CopySQLClient(object):
 
         try:
             response = self.client.send(url,
-                                        http_method='GET',
+                                        http_method=http_method,
                                         params=params,
                                         stream=True)
             response.raise_for_status()
@@ -467,7 +471,7 @@ class CopySQLClient(object):
 
         return response
 
-    def copyto_file_object(self, query, file_object):
+    def copyto_file_object(self, query, file_object, http_method='GET'):
         """
         Gets data from a table into a writable file object
 
@@ -479,13 +483,17 @@ class CopySQLClient(object):
                             Normally the return value of open('file.ext', 'wb')
         :type file_object: file
 
+        :param http_method: HTTP method used in COPY TO request. Options:
+                            'GET' or 'POST'. Default value is False
+        :type http_method: str
+
         :raise CartoException:
         """
-        response = self.copyto(query)
+        response = self.copyto(query, http_method)
         for block in response.iter_content(DEFAULT_CHUNK_SIZE):
             file_object.write(block)
 
-    def copyto_file_path(self, query, path, append=False):
+    def copyto_file_path(self, query, path, append=False, http_method='GET'):
         """
         Gets data from a table into a writable file
 
@@ -500,22 +508,30 @@ class CopySQLClient(object):
                        Default value is False
         :type append: bool
 
+        :param http_method: HTTP method used in COPY TO request. Options:
+                            'GET' or 'POST'. Default value is False
+        :type http_method: str
+
         :raise CartoException:
         """
         file_mode = 'wb' if not append else 'ab'
         with open(path, file_mode) as f:
-            self.copyto_file_object(query, f)
+            self.copyto_file_object(query, f, http_method)
 
-    def copyto_stream(self, query):
+    def copyto_stream(self, query, http_method='GET'):
         """
         Gets data from a table into a stream
 
         :param query: The "COPY { table_name [(column_name[, ...])] | (query) } TO STDOUT [WITH(option[,...])]" query to execute
         :type query: str
 
+        :param http_method: HTTP method used in COPY TO request. Options:
+                            'GET' or 'POST'. Default value is False
+        :type http_method: str
+
         :return: the data from COPY TO query
         :rtype: raw binary (text stream)
 
         :raise: CartoException
         """
-        return ResponseStream(self.copyto(query))
+        return ResponseStream(self.copyto(query, http_method))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.7.0
-pyrestcli>=0.6.9
+pyrestcli==0.6.11

--- a/tests/secret.py.example
+++ b/tests/secret.py.example
@@ -15,7 +15,7 @@ ONPREM_USERNAME = ""
 ONPREM_API_KEY = ""
 
 # SQL API tests, please fill in
-EXISTING_POINT_DATASET = "tornados"  # This must be the name of an existing dataset with points in user's account; dataset will not be modified
+EXISTING_POINT_DATASET = "tornados_carto_python"  # This must be the name of an existing dataset with points in user's account; dataset will not be modified
 
 # Import API tests, should work out of the box
 EXPORT_VIZ_ID = ""  # If empty, visualization export won't be tested. Look for a valid Id in any of your maps in the builder (something like: 83aa7dea-5888-11e6-b269-0e233c30368f)

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -98,6 +98,7 @@ def test_create_regular_api_key_with_tables(api_key_manager, dataset_manager):
     assert api_key.name == api_key_name
     assert api_key.type == 'regular'
     assert api_key.grants.apis == ["sql", "maps"]
+    assert len(api_key.grants.tables) == 1
     assert api_key.grants.tables[0].schema == api_key_manager.client.username
     assert api_key.grants.tables[0].name == table.name
     assert api_key.grants.tables[0].permissions == ['insert', 'select', 'update']

--- a/tests/test_sql_copy.py
+++ b/tests/test_sql_copy.py
@@ -156,38 +156,10 @@ def test_copyto(copy_client, copyto_sample_query, copyto_expected_result):
     assert result == copyto_expected_result
 
 
-def test_copyto_valid_http_methods(copy_client, copyto_sample_query, copyto_expected_result):
-    valid_http_methods = ['GET', 'get', 'POST', 'post']
-    for http_method in valid_http_methods:
-        response = copy_client.copyto(copyto_sample_query, http_method)
-
-        result = bytearray()
-        for block in response.iter_content(10):
-            result += block
-
-        assert result == copyto_expected_result
-
-
-def test_copyto_invalid_http_methods(copy_client, copyto_sample_query, copyto_expected_result):
-    invalid_http_methods = ['', None, 'invalid', 'PUT', 6, True]
-    for http_method in invalid_http_methods:
-        with pytest.raises(CartoException):
-            copy_client.copyto(copyto_sample_query, http_method)
-
-
 def test_copyto_file_object(copy_client, copyto_sample_query, copyto_expected_result):
     in_memory_target_fileobj = InMemIO()
 
     copy_client.copyto_file_object(copyto_sample_query, in_memory_target_fileobj)
-    assert in_memory_target_fileobj.getvalue() == copyto_expected_result
-
-    in_memory_target_fileobj.close()
-
-
-def test_copyto_file_object_using_post(copy_client, copyto_sample_query, copyto_expected_result):
-    in_memory_target_fileobj = InMemIO()
-
-    copy_client.copyto_file_object(copyto_sample_query, in_memory_target_fileobj, 'POST')
     assert in_memory_target_fileobj.getvalue() == copyto_expected_result
 
     in_memory_target_fileobj.close()
@@ -199,19 +171,7 @@ def test_copyto_file_path(copy_client, copyto_sample_query, copyto_expected_resu
     assert target_path.read() == copyto_expected_result.decode('utf-8')
 
 
-def test_copyto_file_path_using_post(copy_client, copyto_sample_query, copyto_expected_result, tmpdir):
-    target_path = tmpdir.join('carto-python-sdk-copy-test.dump')
-    copy_client.copyto_file_path(copyto_sample_query, target_path.strpath, 'POST')
-    assert target_path.read() == copyto_expected_result.decode('utf-8')
-
-
 def test_copyto_stream(copy_client, copyto_sample_query, copyto_expected_result):
     response = copy_client.copyto_stream(copyto_sample_query)
-
-    assert response.read() == copyto_expected_result
-
-
-def test_copyto_stream_using_post(copy_client, copyto_sample_query, copyto_expected_result):
-    response = copy_client.copyto_stream(copyto_sample_query, 'POST')
 
     assert response.read() == copyto_expected_result

--- a/tests/test_sql_copy.py
+++ b/tests/test_sql_copy.py
@@ -156,26 +156,53 @@ def test_copyto(copy_client, copyto_sample_query, copyto_expected_result):
     assert result == copyto_expected_result
 
 
-def test_copyto_file_object(copy_client, copyto_sample_query,
-                            copyto_expected_result):
+def test_copyto_using_post(copy_client, copyto_sample_query, copyto_expected_result):
+    response = copy_client.copyto(copyto_sample_query, 'POST')
+
+    result = bytearray()
+    for block in response.iter_content(10):
+        result += block
+
+    assert result == copyto_expected_result
+
+
+def test_copyto_file_object(copy_client, copyto_sample_query, copyto_expected_result):
     in_memory_target_fileobj = InMemIO()
 
-    copy_client.copyto_file_object(copyto_sample_query,
-                                   in_memory_target_fileobj)
+    copy_client.copyto_file_object(copyto_sample_query, in_memory_target_fileobj)
     assert in_memory_target_fileobj.getvalue() == copyto_expected_result
 
     in_memory_target_fileobj.close()
 
 
-def test_copyto_file_path(copy_client, copyto_sample_query,
-                          copyto_expected_result, tmpdir):
+def test_copyto_file_object_using_post(copy_client, copyto_sample_query, copyto_expected_result):
+    in_memory_target_fileobj = InMemIO()
+
+    copy_client.copyto_file_object(copyto_sample_query, in_memory_target_fileobj, 'POST')
+    assert in_memory_target_fileobj.getvalue() == copyto_expected_result
+
+    in_memory_target_fileobj.close()
+
+
+def test_copyto_file_path(copy_client, copyto_sample_query, copyto_expected_result, tmpdir):
     target_path = tmpdir.join('carto-python-sdk-copy-test.dump')
     copy_client.copyto_file_path(copyto_sample_query, target_path.strpath)
     assert target_path.read() == copyto_expected_result.decode('utf-8')
 
 
-def test_copyto_stream(copy_client, copyto_sample_query,
-                       copyto_expected_result):
+def test_copyto_file_path(copy_client, copyto_sample_query, copyto_expected_result, tmpdir):
+    target_path = tmpdir.join('carto-python-sdk-copy-test.dump')
+    copy_client.copyto_file_path(copyto_sample_query, target_path.strpath, 'POST')
+    assert target_path.read() == copyto_expected_result.decode('utf-8')
+
+
+def test_copyto_stream(copy_client, copyto_sample_query, copyto_expected_result):
     response = copy_client.copyto_stream(copyto_sample_query)
+
+    assert response.read() == copyto_expected_result
+
+
+def test_copyto_stream(copy_client, copyto_sample_query, copyto_expected_result):
+    response = copy_client.copyto_stream(copyto_sample_query, 'POST')
 
     assert response.read() == copyto_expected_result

--- a/tests/test_sql_copy.py
+++ b/tests/test_sql_copy.py
@@ -156,14 +156,23 @@ def test_copyto(copy_client, copyto_sample_query, copyto_expected_result):
     assert result == copyto_expected_result
 
 
-def test_copyto_using_post(copy_client, copyto_sample_query, copyto_expected_result):
-    response = copy_client.copyto(copyto_sample_query, 'POST')
+def test_copyto_valid_http_methods(copy_client, copyto_sample_query, copyto_expected_result):
+    valid_http_methods = ['GET', 'get', 'POST', 'post']
+    for http_method in valid_http_methods:
+        response = copy_client.copyto(copyto_sample_query, http_method)
 
-    result = bytearray()
-    for block in response.iter_content(10):
-        result += block
+        result = bytearray()
+        for block in response.iter_content(10):
+            result += block
 
-    assert result == copyto_expected_result
+        assert result == copyto_expected_result
+
+
+def test_copyto_invalid_http_methods(copy_client, copyto_sample_query, copyto_expected_result):
+    invalid_http_methods = ['', None, 'invalid', 'PUT', 6, True]
+    for http_method in invalid_http_methods:
+        with pytest.raises(CartoException):
+            copy_client.copyto(copyto_sample_query, http_method)
 
 
 def test_copyto_file_object(copy_client, copyto_sample_query, copyto_expected_result):

--- a/tests/test_sql_copy.py
+++ b/tests/test_sql_copy.py
@@ -199,7 +199,7 @@ def test_copyto_file_path(copy_client, copyto_sample_query, copyto_expected_resu
     assert target_path.read() == copyto_expected_result.decode('utf-8')
 
 
-def test_copyto_file_path(copy_client, copyto_sample_query, copyto_expected_result, tmpdir):
+def test_copyto_file_path_using_post(copy_client, copyto_sample_query, copyto_expected_result, tmpdir):
     target_path = tmpdir.join('carto-python-sdk-copy-test.dump')
     copy_client.copyto_file_path(copyto_sample_query, target_path.strpath, 'POST')
     assert target_path.read() == copyto_expected_result.decode('utf-8')
@@ -211,7 +211,7 @@ def test_copyto_stream(copy_client, copyto_sample_query, copyto_expected_result)
     assert response.read() == copyto_expected_result
 
 
-def test_copyto_stream(copy_client, copyto_sample_query, copyto_expected_result):
+def test_copyto_stream_using_post(copy_client, copyto_sample_query, copyto_expected_result):
     response = copy_client.copyto_stream(copyto_sample_query, 'POST')
 
     assert response.read() == copyto_expected_result


### PR DESCRIPTION
Solves https://github.com/CartoDB/carto-python/issues/141

In copy to endpoint, we are going to use GET by default and POST if the query is longer than 1024 bytes