### PR TITLE
default resource id

### DIFF
--- a/carto/do_token.py
+++ b/carto/do_token.py
@@ -47,3 +47,6 @@ class DoTokenManager(Manager):
     resource_class = DoToken
     json_collection_attribute = None
     paginator_class = CartoPaginator
+
+    def get(self):
+        return super(DoTokenManager, self).get('token')


### PR DESCRIPTION
I removed the default resource id of DoTokenManager in the previous PR but since there is no more options, we should keep it