### PR TITLE
Metadata queries broken in Windows

### DIFF
--- a/carto/do_dataset.py
+++ b/carto/do_dataset.py
@@ -173,7 +173,7 @@ class _DODatasetClient:
         params = {'api_key': self.api_key}
         if filters is not None:
             params.update(filters)
-        relative_path = os.path.join(METADATA_BASE_PATH, entity)
+        relative_path = '{}/{}'.format(METADATA_BASE_PATH, entity)
 
         try:
             response = self.auth_client.send(relative_path, 'GET', params=params)


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cartoteam/story/69476

There are other ways of solving this. For a full discussion see https://stackoverflow.com/questions/1793261/how-to-join-components-of-a-path-when-you-are-constructing-a-url-in-python

but IMHO not worth the complexity, plus `format` is clear and kind of standard throughout the code.