### PR TITLE
Add function to delete an API KEY

### DIFF
--- a/carto/api_keys.py
+++ b/carto/api_keys.py
@@ -69,6 +69,22 @@ class APIKey(Resource):
         except Exception as e:
             raise CartoException(e)
 
+    def delete(self):
+        """
+        Removes the API KEY
+
+        :return:
+
+        :raise: CartoException
+        """
+        try:
+            endpoint = (self.Meta.collection_endpoint
+                        + "{name}"). \
+                format(name=self.name)
+
+            self.send(endpoint, "DELETE")
+        except Exception as exception:
+            raise CartoException(exception)
 
 class APIKeyManager(Manager):
     """

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -183,3 +183,22 @@ def test_api_key_manager_filter_multiple(api_key_manager):
     api_keys = api_key_manager.filter(type='default,master')
 
     assert len(api_keys) == 2
+
+def test_delete_api_key(api_key_manager):
+    grants = [
+        {
+            "type": "apis",
+            "apis": ["sql", "maps"]
+        },
+        {
+            "type": "database",
+            "tables": []
+        }
+    ]
+    api_key_name = create_api_key(api_key_manager, grants)
+    api_key = api_key_manager.get(api_key_name)
+    api_key.delete()
+    with pytest.raises(NotFoundException) as exception:
+        api_key_manager.get(api_key_name)
+    assert "API key not found" in str(exception.value)
+


### PR DESCRIPTION
## Resources
[Clubhouse story](https://app.clubhouse.io/cartoteam/story/166870/cardamon-dna-cartoframes-kuviz-uses-cached-api-key-without-permissions-upon-map-publication)

## Context
We should be able to manage the API KEYS and delete one of them if needed.

## Changes
- [x] Add functionality to delete API KEYS